### PR TITLE
Remove unnecessary overrideLibrary

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,11 +20,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.feedhenry.saml">
 
-    <uses-sdk tools:overrideLibrary="org.jboss.aerogear.android.core,
-                                     org.jboss.aerogear.android.pipe,
-                                     org.jboss.aerogear.android.unifiedpush,
-                                     com.google.android.gms" />
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 


### PR DESCRIPTION
AG Push library now is a [provided dependency](https://github.com/feedhenry/fh-android-sdk/blob/master/fh-android-sdk/pom.xml#L41-L47) on fh-android-sdk, so, we don't need to use overrideLibrary in app using minSdkVersion < AG Push minSdkVersion
