### PR TITLE
Android N with Jack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,40 +5,59 @@ dist: precise
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
 
 android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.2
+    - build-tools-24.0.3
     - android-22
     - android-23
+    - android-24
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
-    - sys-img-armeabi-v7a-android-10
-    - sys-img-armeabi-v7a-android-15
-    - sys-img-armeabi-v7a-android-16
-    - sys-img-armeabi-v7a-android-17
-    - sys-img-armeabi-v7a-android-18
-    - sys-img-armeabi-v7a-android-19
-    - sys-img-armeabi-v7a-android-21
-    - sys-img-armeabi-v7a-android-22
+licenses:
+    - android-sdk-license-5be876d5
 
 env:
+  global:
+    - ADB_INSTALL_TIMEOUT=10
   matrix:
-    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi
-    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi     ANDROID_PKGS=sys-img-armeabi-v7a-android-10
+    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-15
+    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-16
+    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-17
+    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-18
+    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-19
+    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-21
+    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-22
+    - ANDROID_EMULATOR=android-23 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-23
+    - ANDROID_EMULATOR=android-24 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-24
+
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+before_install:
+  - echo y | android update sdk -a -u -t ${ANDROID_PKGS:-}
+
+install:
+  - echo no | android create avd --force -n test -t "$ANDROID_EMULATOR" --abi "$ANDROID_ABI"
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - adb wait-for-device get-serialno
+  - ./gradlew --version
+  - ./gradlew clean
 
 before_script:
-  - echo no | android create avd --force -n test -t $ANDROID_EMULATOR --abi $ANDROID_ABI
-  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+script:
+  - ./gradlew build connectedCheck
+
+after_script:
+  - cat logcat.log; pkill -KILL -f adb

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ license {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile 'com.feedhenry:fh-android-sdk:3.1.0'
+    compile 'com.feedhenry:fh-android-sdk:3.2.0'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ plugins {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.3"
 
     defaultConfig {
         applicationId "org.feedhenry.saml"
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
     }
@@ -42,6 +42,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     compile 'com.feedhenry:fh-android-sdk:3.2.0'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:design:24.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,14 @@ android {
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+        jackOptions {
+            enabled true
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Related Jiras:
- [FH-2817](https://issues.jboss.org/browse/FH-2817) - Update fh-android-sdk dependency in all Android template for 3.2.0
- [FH-2705](https://issues.jboss.org/browse/FH-2705) - Update Android Plugin for Gradle on templates
- [FH-2735](https://issues.jboss.org/browse/FH-2735) - Update templates to target Android N 
- [FH-2737](https://issues.jboss.org/browse/FH-2737) - Update templates to use Jack
